### PR TITLE
Pass jshint, better pasting, some small tweaks 

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,8 @@
+{
+  "predef": [
+    // Node comes with console, so does every modern browser
+    "console"
+  ],
+  "asi" : true, // Tolerate Automatic Semicolon Insertion (no semicolons).
+  "esnext": true
+}

--- a/.jshintrc
+++ b/.jshintrc
@@ -2,7 +2,5 @@
   "predef": [
     // Node comes with console, so does every modern browser
     "console"
-  ],
-  "asi" : true, // Tolerate Automatic Semicolon Insertion (no semicolons).
-  "esnext": true
+  ]
 }

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,6 +1,3 @@
 {
-  "predef": [
-    // Node comes with console, so does every modern browser
-    "console"
-  ]
+	"browser" : true
 }

--- a/README.md
+++ b/README.md
@@ -1,45 +1,31 @@
-tags-input [![NPM Version](http://img.shields.io/npm/v/tags-input.svg?style=flat)](https://www.npmjs.org/package/tags-input) [![Bower Version](http://img.shields.io/bower/v/tags-input.svg?style=flat)](http://bower.io/search/?q=tags-input)
-=========
+# tags-input
+
+[![NPM Version](http://img.shields.io/npm/v/tags-input.svg?style=flat)](https://www.npmjs.org/package/tags-input)
 
 [![Join the chat at https://gitter.im/developit/tags-input](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/developit/tags-input?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-**Features:**
+## Features
 
 - I said `<input type="tags">` should be a thing.
 - With full keyboard and mouse support.
 - Works with HTML5 `pattern` and `placeholder` attributes, too!
 - Native [`change`](https://developer.mozilla.org/en-US/docs/Web/Events/change) and [`input`](https://developer.mozilla.org/en-US/docs/Web/Events/input) _("live" change)_ events.
 
-**Screenshot:**
+## Screenshot
 
 > ![screenshot](http://cl.ly/image/3M3U1h1s2y0v/tags-screenshot.png)
 
 [JSFiddle Demo](http://jsfiddle.net/developit/d5w4jpxq/)
 
----
+## Usage
 
+It's an npm module!
 
-Examples
-========
-
-It's easy to use! In addition to the code from either the RequireJS or CommonJS examples,
-you'll also need to include `tags-input.css` - I didn't bundle it because that's a bit gross.
-
-**RequireJS Example:**
-
-```JavaScript
-// AMD if you want:
-define(['tags-input'], function(tagsInput) {
-
-	// enhance all tag inputs on the page:
-	[].forEach.call(document.querySelectorAll('input[type="tags"]'), tagsInput);
-
-	// Or just enhance a specific element:
-	tagsInput(document.getElementById('hashtags'));
-});
+```
+npm install --save tags-input
 ```
 
-**Verbose CommonJS Example:**
+Then, in your JavaScript:
 
 ```JavaScript
 var tagsInput = require('tags-input');
@@ -49,19 +35,4 @@ tags.setAttribute('type', 'tags');
 tagsInput(tags);
 document.body.appendChild(tags);
 ```
-
-**HTML Example:**
-
-```html
-<link rel="stylesheet" href="tags-input.css">
-<script src="tags-input.js"></script>
-
-<form>
-	<label>
-		Add some
-		<input name="hashtags" type="tags" pattern="^#" placeholder="#hashtags">
-	</label>
-</form>
-
-<script>[].forEach.call(document.querySelectorAll('input[type="tags"]'), tagsInput);</script>
-```
+After loading the the npm module, you'll also need to include `tags-input.css`.

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "tags-input",
-  "version": "0.6.0",
+  "version": "0.8.1",
   "homepage": "https://github.com/developit/tags-input",
   "authors": [
     "Jason Miller <jason@developit.ca>"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tags-input",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "main": "tags-input.js",
   "description": "<input type=\"tags\"> like magic.",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tags-input",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "main": "tags-input.js",
   "description": "<input type=\"tags\"> like magic.",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tags-input",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "main": "tags-input.js",
   "description": "<input type=\"tags\"> like magic.",
   "repository": {

--- a/tags-input.js
+++ b/tags-input.js
@@ -226,8 +226,12 @@
 				// If there are no tags yet, update the original input as the user types -
 				// so that users who only want one thing don't have to enter commas
 				if ( ! $('.tag', true).length ) {
-					originalInput.value = getValue();
-					originalInput.dispatchEvent(new Event('input'));
+					// Wait one tick (ie 0) so the key gets added to the input
+					setTimeout(function(){
+						originalInput.value = getValue();
+						originalInput.dispatchEvent(new Event('input'));
+					}, 0);
+
 				}
 				return select();
 			}

--- a/tags-input.js
+++ b/tags-input.js
@@ -1,268 +1,250 @@
-(function(g, factory) {
-	if (typeof define==='function' && define.amd) {
-		define([], factory);
+var SEPERATOR = ',';
+
+var BACKSPACE = 8,
+	TAB = 9,
+	ENTER = 13,
+	LEFT = 37,
+	RIGHT = 39,
+	DELETE = 46,
+	COMMA = 188;
+
+module.exports = function tagsInput(originalInput) {
+	function createElement(type, name, text, attributes) {
+		var el = document.createElement(type);
+		if (name) {
+			el.className = name;
+		}
+		if (text) {
+			el.textContent = text;
+		}
+		for ( var attributeName in attributes ) {
+			el.setAttribute('data-'+attributeName, attributes[attributeName]);
+		}
+		return el;
 	}
-	else if (typeof module==='object' && typeof require==='function') {
-		module.exports = factory();
+
+	function $(selector, all) {
+		return base['querySelector'+(all?'All':'')](selector);
 	}
-	else {
-		g.tagsInput = factory();
+
+	function getLastElement(nodeList){
+		if ( nodeList ) {
+			return nodeList[nodeList.length - 1];
+		}
+		return null;
 	}
-}(this, function() {
 
-	var SEPERATOR = ',';
-
-	var BACKSPACE = 8,
-		TAB = 9,
-		ENTER = 13,
-		LEFT = 37,
-		RIGHT = 39,
-		DELETE = 46,
-		COMMA = 188;
-
-	function tagsInput(originalInput) {
-		function createElement(type, name, text, attributes) {
-			var el = document.createElement(type);
-			if (name) {
-				el.className = name;
-			}
-			if (text) {
-				el.textContent = text;
-			}
-			for ( var attributeName in attributes ) {
-				el.setAttribute('data-'+attributeName, attributes[attributeName]);
-			}
-			return el;
+	// Get value of everything entered thus far - both existing tags and new input.
+	function getValue() {
+		// Tags
+		var tagValues = Array.prototype.map.call($('.tag', true), function(tag) {
+				return tag.textContent;
+			}),
+			// In progress input
+			inProgress = base.input.value;
+		if (inProgress) {
+			tagValues.push(inProgress);
 		}
+		return tagValues.join(SEPERATOR);
+	}
 
-		function $(selector, all) {
-			return base['querySelector'+(all?'All':'')](selector);
-		}
+	function save() {
+		originalInput.value = getValue();
+		originalInput.dispatchEvent(new Event('change'));
+	}
 
-		function getLastElement(nodeList){
-			if ( nodeList ) {
-				return nodeList[nodeList.length - 1];
+	// text:String data entered by user in input element OR existing element value when loading
+	// Return true if we needed to add at least one tag
+	function addTags(text) {
+
+		var addedATag = false;
+		// Add multiple tags if necessary, eg if the user pastes in data with SEPERATOR already in it.
+		var newTagTexts = text.split(SEPERATOR);
+
+		newTagTexts.forEach(function(newTagText){
+			newTagText = newTagText.trim();
+			// Ignore if newTagText is empty
+			if ( ! ( newTagText ) ) {
+				return;
 			}
-			return null;
-		}
-
-		// Get value of everything entered thus far - both existing tags and new input.
-		function getValue() {
-			// Tags
-			var tagValues = Array.prototype.map.call($('.tag', true), function(tag) {
-					return tag.textContent;
-				}),
-				// In progress input
-				inProgress = base.input.value;
-			if (inProgress) {
-				tagValues.push(inProgress);
-			}
-			return tagValues.join(SEPERATOR);
-		}
-
-		function save() {
-			originalInput.value = getValue();
-			originalInput.dispatchEvent(new Event('change'));
-		}
-
-		// text:String data entered by user in input element OR existing element value when loading
-		// Return true if we needed to add at least one tag
-		function addTags(text) {
-
-			var addedATag = false;
-			// Add multiple tags if necessary, eg if the user pastes in data with SEPERATOR already in it.
-			var newTagTexts = text.split(SEPERATOR);
-
-			newTagTexts.forEach(function(newTagText){
-				newTagText = newTagText.trim();
-				// Ignore if newTagText is empty
-				if ( ! ( newTagText ) ) {
+			// For duplicates, briefly highlight the existing tag
+			if ( ! originalInput.getAttribute('duplicates') ) {
+				var existingTag = $('[data-tag="'+newTagText+'"]');
+				if (existingTag) {
+					existingTag.classList.add('dupe');
+					setTimeout(function(){
+						existingTag.classList.remove('dupe');
+					}, 100);
 					return;
 				}
-				// For duplicates, briefly highlight the existing tag
-				if ( ! originalInput.getAttribute('duplicates') ) {
-					var existingTag = $('[data-tag="'+newTagText+'"]');
-					if (existingTag) {
-						existingTag.classList.add('dupe');
-						setTimeout(function(){
-							existingTag.classList.remove('dupe');
-						}, 100);
-						return;
-					}
-				}
-				var tagElement = createElement('span', 'tag', newTagText, {tag: newTagText});
-				base.insertBefore(tagElement, base.input);
-				addedATag = true;
-			});
-			return addedATag;
-		}
-
-		function select(el) {
-			var selectedTag = $('.selected');
-			if (selectedTag) {
-				selectedTag.classList.remove('selected');
 			}
-			if (el) {
-				el.classList.add('selected');
-			}
-		}
-
-		function setInputWidth() {
-			if ( ! base.offsetWidth) {
-				return;
-			}
-			var lastTag = getLastElement($('.tag', true));
-			base.input.style.width = Math.max(
-				base.offsetWidth-(lastTag?(lastTag.offsetLeft+lastTag.offsetWidth):5)-5,
-				base.offsetWidth/4
-			) + 'px';
-		}
-
-		function savePartialInput() {
-			if ( addTags(base.input.value) ) {
-				base.input.value = '';
-				save();
-				setInputWidth();
-			}
-		}
-
-		function refocus(e) {
-			if (e.target.classList.contains('tag')) {
-				select(e.target);
-			}
-			if (e.target===base.input) {
-				select();
-				return;
-			}
-			base.input.focus();
-			e.preventDefault();
-			return false;
-		}
-
-		var base = createElement('div', 'tags-input'),
-			sib = originalInput.nextSibling;
-
-		originalInput.parentNode[sib?'insertBefore':'appendChild'](base, sib);
-
-		originalInput.style.cssText = 'position:absolute;left:0;top:-99px;width:1px;height:1px;opacity:0.01;';
-		originalInput.tabIndex = -1;
-
-		base.input = createElement('input', null, null, {
-			'type': 'text',
-			'placeholder': originalInput.placeholder,
-			'pattern': originalInput.pattern,
-			'spellcheck': originalInput.spellcheck,
-			'autocorrect': originalInput.autocorrect,
-			'autocapitalize': originalInput.autocapitalize,
-			'autosuggest': originalInput.autocapitalize
+			var tagElement = createElement('span', 'tag', newTagText, {tag: newTagText});
+			base.insertBefore(tagElement, base.input);
+			addedATag = true;
 		});
-		base.appendChild(base.input);
+		return addedATag;
+	}
 
-		delete originalInput.pattern;
-		originalInput.addEventListener('focus', function() {
-			base.input.focus();
-		});
+	function select(el) {
+		var selectedTag = $('.selected');
+		if (selectedTag) {
+			selectedTag.classList.remove('selected');
+		}
+		if (el) {
+			el.classList.add('selected');
+		}
+	}
 
-		base.input.addEventListener('focus', function() {
-			base.classList.add('focus');
-			select();
-		});
+	function setInputWidth() {
+		if ( ! base.offsetWidth) {
+			return;
+		}
+		var lastTag = getLastElement($('.tag', true));
+		base.input.style.width = Math.max(
+			base.offsetWidth-(lastTag?(lastTag.offsetLeft+lastTag.offsetWidth):5)-5,
+			base.offsetWidth/4
+		) + 'px';
+	}
 
-		base.input.addEventListener('blur', function() {
-			base.classList.remove('focus');
-			select();
-			savePartialInput();
-		});
-
-		base.input.addEventListener('keydown', function(e) {
-			var key = e.keyCode || e.which,
-				selectedTag = $('.tag.selected'),
-				pos = this.selectionStart===this.selectionEnd && this.selectionStart,
-				lastTag = getLastElement($('.tag', true));
-
+	function savePartialInput() {
+		if ( addTags(base.input.value) ) {
+			base.input.value = '';
+			save();
 			setInputWidth();
+		}
+	}
 
-			if (key===ENTER || key===COMMA || key===TAB) {
-				if (!this.value && key!==COMMA) {
-					return;
-				}
-				savePartialInput();
+	function refocus(e) {
+		if (e.target.classList.contains('tag')) {
+			select(e.target);
+		}
+		if (e.target===base.input) {
+			select();
+			return;
+		}
+		base.input.focus();
+		e.preventDefault();
+		return false;
+	}
+
+	var base = createElement('div', 'tags-input'),
+		sib = originalInput.nextSibling;
+
+	originalInput.parentNode[sib?'insertBefore':'appendChild'](base, sib);
+
+	originalInput.style.cssText = 'position:absolute;left:0;top:-99px;width:1px;height:1px;opacity:0.01;';
+	originalInput.tabIndex = -1;
+
+	base.input = createElement('input', null, null, {
+		'type': 'text',
+		'placeholder': originalInput.placeholder,
+		'pattern': originalInput.pattern,
+		'spellcheck': originalInput.spellcheck,
+		'autocorrect': originalInput.autocorrect,
+		'autocapitalize': originalInput.autocapitalize,
+		'autosuggest': originalInput.autocapitalize
+	});
+	base.appendChild(base.input);
+
+	delete originalInput.pattern;
+	originalInput.addEventListener('focus', function() {
+		base.input.focus();
+	});
+
+	base.input.addEventListener('focus', function() {
+		base.classList.add('focus');
+		select();
+	});
+
+	base.input.addEventListener('blur', function() {
+		base.classList.remove('focus');
+		select();
+		savePartialInput();
+	});
+
+	base.input.addEventListener('keydown', function(e) {
+		var key = e.keyCode || e.which,
+			selectedTag = $('.tag.selected'),
+			pos = this.selectionStart===this.selectionEnd && this.selectionStart,
+			lastTag = getLastElement($('.tag', true));
+
+		setInputWidth();
+
+		if (key===ENTER || key===COMMA || key===TAB) {
+			if (!this.value && key!==COMMA) {
+				return;
 			}
-			else if (key===DELETE && selectedTag) {
-				if (selectedTag.nextSibling!==base.input) {
-					select(selectedTag.nextSibling);
-				}
+			savePartialInput();
+		}
+		else if (key===DELETE && selectedTag) {
+			if (selectedTag.nextSibling!==base.input) {
+				select(selectedTag.nextSibling);
+			}
+			base.removeChild(selectedTag);
+			setInputWidth();
+			save();
+		}
+		else if (key===BACKSPACE) {
+			if (selectedTag) {
+				select(selectedTag.previousSibling);
 				base.removeChild(selectedTag);
 				setInputWidth();
 				save();
 			}
-			else if (key===BACKSPACE) {
-				if (selectedTag) {
-					select(selectedTag.previousSibling);
-					base.removeChild(selectedTag);
-					setInputWidth();
-					save();
-				}
-				else if (lastTag && pos===0) {
-					select(lastTag);
-				}
-				else {
-					return;
-				}
-			}
-			else if (key===LEFT) {
-				if (selectedTag) {
-					if (selectedTag.previousSibling) {
-						select(selectedTag.previousSibling);
-					}
-				}
-				else if (pos!==0) {
-					return;
-				}
-				else {
-					select(lastTag);
-				}
-			}
-			else if (key===RIGHT) {
-				if (!selectedTag) {
-					return;
-				}
-				select(selectedTag.nextSibling);
+			else if (lastTag && pos===0) {
+				select(lastTag);
 			}
 			else {
-				// If there are no tags yet, update the original input as the user types -
-				// so that users who only want one thing don't have to enter commas
-				if ( ! $('.tag', true).length ) {
-					// Wait one tick (ie 0) so the key gets added to the input
-					setTimeout(function(){
-						originalInput.value = getValue();
-						originalInput.dispatchEvent(new Event('input'));
-					}, 0);
-
-				}
-				return select();
+				return;
 			}
-			e.preventDefault();
-			return false;
-		});
+		}
+		else if (key===LEFT) {
+			if (selectedTag) {
+				if (selectedTag.previousSibling) {
+					select(selectedTag.previousSibling);
+				}
+			}
+			else if (pos!==0) {
+				return;
+			}
+			else {
+				select(lastTag);
+			}
+		}
+		else if (key===RIGHT) {
+			if (!selectedTag) {
+				return;
+			}
+			select(selectedTag.nextSibling);
+		}
+		else {
+			// If there are no tags yet, update the original input as the user types -
+			// so that users who only want one thing don't have to enter commas
+			if ( ! $('.tag', true).length ) {
+				// Wait one tick (ie 0) so the key gets added to the input
+				setTimeout(function(){
+					originalInput.value = getValue();
+					originalInput.dispatchEvent(new Event('input'));
+				}, 0);
 
-		base.input.addEventListener('paste', function(e) {
-			// Wait one tick (ie 0) so base.input gets filled from the paste, then save it.
-			setTimeout(function(){
-				savePartialInput();
-			}, 0);
-		});
+			}
+			return select();
+		}
+		e.preventDefault();
+		return false;
+	});
 
-		base.addEventListener('mousedown', refocus);
-		base.addEventListener('touchstart', refocus);
+	base.input.addEventListener('paste', function(e) {
+		// Wait one tick (ie 0) so base.input gets filled from the paste, then save it.
+		setTimeout(function(){
+			savePartialInput();
+		}, 0);
+	});
 
-		// Add tags for existing values
-		addTags(originalInput.value);
-		setInputWidth();
-	}
+	base.addEventListener('mousedown', refocus);
+	base.addEventListener('touchstart', refocus);
 
-	// make life easier:
-	tagsInput.enhance = tagsInput.tagsInput = tagsInput;
-
-	return tagsInput;
-}));
+	// Add tags for existing values
+	addTags(originalInput.value);
+	setInputWidth();
+};

--- a/tags-input.js
+++ b/tags-input.js
@@ -20,7 +20,7 @@
 		DELETE = 46,
 		COMMA = 188;
 
-	function tagsInput(input) {
+	function tagsInput(originalInput) {
 		function createElement(type, name, text, attributes) {
 			var el = document.createElement(type);
 			if (name) {
@@ -52,8 +52,8 @@
 		}
 
 		function save() {
-			input.value = getValue();
-			input.dispatchEvent(new Event('change'));
+			originalInput.value = getValue();
+			originalInput.dispatchEvent(new Event('change'));
 		}
 
 		// text:String data entered by user in input element OR existing element value when loading
@@ -71,7 +71,7 @@
 					return;
 				}
 				// For duplicates, briefly highlight the existing tag
-				if ( ! input.getAttribute('duplicates') ) {
+				if ( ! originalInput.getAttribute('duplicates') ) {
 					var existingTag = $('[data-tag="'+newTagText+'"]');
 					if (existingTag) {
 						existingTag.classList.add('dupe');
@@ -131,21 +131,21 @@
 		}
 
 		var base = createElement('div', 'tags-input'),
-			sib = input.nextSibling;
+			sib = originalInput.nextSibling;
 
-		input.parentNode[sib?'insertBefore':'appendChild'](base, sib);
+		originalInput.parentNode[sib?'insertBefore':'appendChild'](base, sib);
 
-		input.style.cssText = 'position:absolute;left:0;top:-99px;width:1px;height:1px;opacity:0.01;';
-		input.tabIndex = -1;
+		originalInput.style.cssText = 'position:absolute;left:0;top:-99px;width:1px;height:1px;opacity:0.01;';
+		originalInput.tabIndex = -1;
 
 		base.input = createElement('input');
 		base.input.setAttribute('type', 'text');
-		base.input.placeholder = input.placeholder;
-		base.input.pattern = input.pattern;
+		base.input.placeholder = originalInput.placeholder;
+		base.input.pattern = originalInput.pattern;
 		base.appendChild(base.input);
 
-		delete input.pattern;
-		input.addEventListener('focus', function() {
+		delete originalInput.pattern;
+		originalInput.addEventListener('focus', function() {
 			base.input.focus();
 		});
 
@@ -225,16 +225,16 @@
 
 		// Proxy "input" (live change) events , update the first tag live as the user types
 		// This means that users who only want one thing don't have to enter commas
-		base.input.addEventListener('input', function(e) {
-			input.value = getValue();
-			input.dispatchEvent(new Event('input'));
+		base.input.addEventListener('originalInput', function(e) {
+			originalInput.value = getValue();
+			originalInput.dispatchEvent(new Event('originalInput'));
 		});
 
 		base.addEventListener('mousedown', refocus);
 		base.addEventListener('touchstart', refocus);
 
 		// Add tags for existing values
-		addTags(input.value);
+		addTags(originalInput.value);
 		setInputWidth();
 	}
 

--- a/tags-input.js
+++ b/tags-input.js
@@ -220,7 +220,7 @@
 				// so that users who only want one thing don't have to enter commas
 				if ( ! $('.tag', true).length ) {
 					originalInput.value = getValue();
-					originalInput.dispatchEvent(new Event('originalInput'));
+					originalInput.dispatchEvent(new Event('input'));
 				}
 				return select();
 			}
@@ -232,7 +232,7 @@
 			// Wait one tick (ie 0) so base.input gets filled from the paste, then save it.
 			setTimeout(function(){
 				savePartialInput();
-			}, 0)
+			}, 0);
 		});
 
 		base.addEventListener('mousedown', refocus);

--- a/tags-input.js
+++ b/tags-input.js
@@ -138,10 +138,15 @@
 		originalInput.style.cssText = 'position:absolute;left:0;top:-99px;width:1px;height:1px;opacity:0.01;';
 		originalInput.tabIndex = -1;
 
-		base.input = createElement('input');
-		base.input.setAttribute('type', 'text');
-		base.input.placeholder = originalInput.placeholder;
-		base.input.pattern = originalInput.pattern;
+		base.input = createElement('input', null, null, {
+			'type': 'text',
+			'placeholder': originalInput.placeholder,
+			'pattern': originalInput.pattern,
+			'spellcheck': originalInput.spellcheck,
+			'autocorrect': originalInput.autocorrect,
+			'autocapitalize': originalInput.autocapitalize,
+			'autosuggest': originalInput.autocapitalize
+		});
 		base.appendChild(base.input);
 
 		delete originalInput.pattern;

--- a/tags-input.js
+++ b/tags-input.js
@@ -39,16 +39,18 @@
 			return base['querySelector'+(all?'All':'')](selector);
 		}
 
-		// Get value of everything entered this far - existing tags, new input, etc.
+		// Get value of everything entered thus far - both existing tags and new input.
 		function getValue() {
-			var arr = Array.prototype.map.call($('.tag', true), function(tag) {
+			// Tags
+			var tagValues = Array.prototype.map.call($('.tag', true), function(tag) {
 					return tag.textContent;
 				}),
-				v = base.input.value;
-			if (v) {
-				arr.push(v);
+				// In progress input
+				inProgress = base.input.value;
+			if (inProgress) {
+				tagValues.push(inProgress);
 			}
-			return arr.join(SEPERATOR);
+			return tagValues.join(SEPERATOR);
 		}
 
 		function save() {

--- a/tags-input.js
+++ b/tags-input.js
@@ -10,7 +10,7 @@
 	}
 }(this, function() {
 
-	var SEPERATOR = ','
+	var SEPERATOR = ',';
 
 	var BACKSPACE = 8,
 		TAB = 9,
@@ -35,6 +35,7 @@
 			return base['querySelector'+(all?'All':'')](selector);
 		}
 
+		// Get value of everything entered this far - existing tags, new input, etc.
 		function getValue() {
 			var arr = Array.prototype.map.call($('.tag', true), function(tag) {
 					return tag.textContent;
@@ -51,27 +52,35 @@
 			input.dispatchEvent(new Event('change'));
 		}
 
-		// Return false if no need to add a tag
-		function addTag(text) {
-			text = text.trim()
-			// Ignore if text is empty
-			if ( ! ( text ) ) return false;
-			// For duplicates, briefly highlight the existing tag
-			if (!input.getAttribute('duplicates')) {
-				var exisingTag = $('[data-tag="'+text+'"]');
-				if (exisingTag) {
-					exisingTag.classList.add('dupe');
-					setTimeout(function(){ exisingTag.classList.remove('dupe'); }, 100);
-					return false;
-				}
-			}
-			// Add multiple tags if the user pastes in data with SEPERATOR already in it.
+		// text:String data entered by user in input element OR existing element value when loading
+		// Return true if we needed to add at least one tag
+		function addTags(text) {
+
+			var addedATag = false;
+			// Add multiple tags if necessary, eg if the user pastes in data with SEPERATOR already in it.
 			var newTagTexts = text.split(SEPERATOR)
+
 			newTagTexts.forEach(function(newTagText){
 				newTagText = newTagText.trim()
+				// Ignore if newTagText is empty
+				if ( ! ( newTagText ) ) return;
+				// For duplicates, briefly highlight the existing tag
+				log("Checking for dupe", newTagText)
+				if ( ! input.getAttribute('duplicates') ) {
+					var existingTag = $('[data-tag="'+newTagText+'"]');
+					if (existingTag) {
+						existingTag.classList.add('dupe');
+						setTimeout(function(){
+							existingTag.classList.remove('dupe');
+						}, 100);
+						return;
+					}
+				}
 				var tagElement = createElement('span', 'tag', newTagText, {tag: newTagText})
 				base.insertBefore(tagElement, base.input);
+				addedATag = true
 			})
+			return addedATag;
 		}
 
 		function select(el) {
@@ -90,7 +99,7 @@
 		}
 
 		function savePartialInput() {
-			if (addTag(base.input.value)!==false) {
+			if ( addTags(base.input.value) ) {
 				base.input.value = '';
 				save();
 				setInputWidth();
@@ -208,7 +217,7 @@
 		base.addEventListener('touchstart', refocus);
 
 		// Add tags for existing values
-		input.value.split(SEPERATOR).forEach(addTag);
+		addTags(input.value);
 		setInputWidth();
 	}
 

--- a/tags-input.js
+++ b/tags-input.js
@@ -228,6 +228,13 @@
 			return false;
 		});
 
+		base.input.addEventListener('paste', function(e) {
+			// Wait one tick (ie 0) so base.input gets filled from the paste, then save it.
+			setTimeout(function(){
+				savePartialInput();
+			}, 0)
+		});
+
 		base.addEventListener('mousedown', refocus);
 		base.addEventListener('touchstart', refocus);
 

--- a/tags-input.js
+++ b/tags-input.js
@@ -39,6 +39,13 @@
 			return base['querySelector'+(all?'All':'')](selector);
 		}
 
+		function getLastElement(nodeList){
+			if ( nodeList ) {
+				return nodeList[nodeList.length - 1];
+			}
+			return null;
+		}
+
 		// Get value of everything entered thus far - both existing tags and new input.
 		function getValue() {
 			// Tags
@@ -101,12 +108,12 @@
 		}
 
 		function setInputWidth() {
-			var last = [].pop.call($('.tag',true));
-			if (!base.offsetWidth) {
+			if ( ! base.offsetWidth) {
 				return;
 			}
+			var lastTag = getLastElement($('.tag', true));
 			base.input.style.width = Math.max(
-				base.offsetWidth-(last?(last.offsetLeft+last.offsetWidth):5)-5,
+				base.offsetWidth-(lastTag?(lastTag.offsetLeft+lastTag.offsetWidth):5)-5,
 				base.offsetWidth/4
 			) + 'px';
 		}
@@ -171,7 +178,7 @@
 			var key = e.keyCode || e.which,
 				selectedTag = $('.tag.selected'),
 				pos = this.selectionStart===this.selectionEnd && this.selectionStart,
-				last = [].pop.call($('.tag',true));
+				lastTag = getLastElement($('.tag', true));
 
 			setInputWidth();
 
@@ -196,8 +203,8 @@
 					setInputWidth();
 					save();
 				}
-				else if (last && pos===0) {
-					select(last);
+				else if (lastTag && pos===0) {
+					select(lastTag);
 				}
 				else {
 					return;
@@ -213,7 +220,7 @@
 					return;
 				}
 				else {
-					select(last);
+					select(lastTag);
 				}
 			}
 			else if (key===RIGHT) {

--- a/tags-input.js
+++ b/tags-input.js
@@ -216,18 +216,16 @@
 				select(selectedTag.nextSibling);
 			}
 			else {
+				// If there are no tags yet, update the original input as the user types -
+				// so that users who only want one thing don't have to enter commas
+				if ( ! $('.tag', true).length ) {
+					originalInput.value = getValue();
+					originalInput.dispatchEvent(new Event('originalInput'));
+				}
 				return select();
 			}
-
 			e.preventDefault();
 			return false;
-		});
-
-		// Proxy "input" (live change) events , update the first tag live as the user types
-		// This means that users who only want one thing don't have to enter commas
-		base.input.addEventListener('input', function(e) {
-			originalInput.value = getValue();
-			originalInput.dispatchEvent(new Event('originalInput'));
 		});
 
 		base.addEventListener('mousedown', refocus);

--- a/tags-input.js
+++ b/tags-input.js
@@ -225,7 +225,7 @@
 
 		// Proxy "input" (live change) events , update the first tag live as the user types
 		// This means that users who only want one thing don't have to enter commas
-		base.input.addEventListener('originalInput', function(e) {
+		base.input.addEventListener('input', function(e) {
 			originalInput.value = getValue();
 			originalInput.dispatchEvent(new Event('originalInput'));
 		});

--- a/tags-input.js
+++ b/tags-input.js
@@ -23,10 +23,14 @@
 	function tagsInput(input) {
 		function createElement(type, name, text, attributes) {
 			var el = document.createElement(type);
-			if (name) el.className = name;
-			if (text) el.textContent = text;
+			if (name) {
+				el.className = name;
+			}
+			if (text) {
+				el.textContent = text;
+			}
 			for ( var attributeName in attributes ) {
-				el.setAttribute('data-'+attributeName, attributes[attributeName])
+				el.setAttribute('data-'+attributeName, attributes[attributeName]);
 			}
 			return el;
 		}
@@ -58,14 +62,15 @@
 
 			var addedATag = false;
 			// Add multiple tags if necessary, eg if the user pastes in data with SEPERATOR already in it.
-			var newTagTexts = text.split(SEPERATOR)
+			var newTagTexts = text.split(SEPERATOR);
 
 			newTagTexts.forEach(function(newTagText){
-				newTagText = newTagText.trim()
+				newTagText = newTagText.trim();
 				// Ignore if newTagText is empty
-				if ( ! ( newTagText ) ) return;
+				if ( ! ( newTagText ) ) {
+					return;
+				}
 				// For duplicates, briefly highlight the existing tag
-				log("Checking for dupe", newTagText)
 				if ( ! input.getAttribute('duplicates') ) {
 					var existingTag = $('[data-tag="'+newTagText+'"]');
 					if (existingTag) {
@@ -76,22 +81,28 @@
 						return;
 					}
 				}
-				var tagElement = createElement('span', 'tag', newTagText, {tag: newTagText})
+				var tagElement = createElement('span', 'tag', newTagText, {tag: newTagText});
 				base.insertBefore(tagElement, base.input);
-				addedATag = true
-			})
+				addedATag = true;
+			});
 			return addedATag;
 		}
 
 		function select(el) {
 			var selectedTag = $('.selected');
-			if (selectedTag) selectedTag.classList.remove('selected');
-			if (el) el.classList.add('selected');
+			if (selectedTag) {
+				selectedTag.classList.remove('selected');
+			}
+			if (el) {
+				el.classList.add('selected');
+			}
 		}
 
 		function setInputWidth() {
 			var last = [].pop.call($('.tag',true));
-			if (!base.offsetWidth) return;
+			if (!base.offsetWidth) {
+				return;
+			}
 			base.input.style.width = Math.max(
 				base.offsetWidth-(last?(last.offsetLeft+last.offsetWidth):5)-5,
 				base.offsetWidth/4
@@ -107,7 +118,9 @@
 		}
 
 		function refocus(e) {
-			if (e.target.classList.contains('tag')) select(e.target);
+			if (e.target.classList.contains('tag')) {
+				select(e.target);
+			}
 			if (e.target===base.input) {
 				select();
 				return;
@@ -156,11 +169,15 @@
 			setInputWidth();
 
 			if (key===ENTER || key===COMMA || key===TAB) {
-				if (!this.value && key!==COMMA) return;
+				if (!this.value && key!==COMMA) {
+					return;
+				}
 				savePartialInput();
 			}
 			else if (key===DELETE && selectedTag) {
-				if (selectedTag.nextSibling!==base.input) select(selectedTag.nextSibling);
+				if (selectedTag.nextSibling!==base.input) {
+					select(selectedTag.nextSibling);
+				}
 				base.removeChild(selectedTag);
 				setInputWidth();
 				save();


### PR DESCRIPTION
This looks like a bigger change than it is. Three parts:
- pass jshint - add some semis, put if bodies on separate lines, etc. Hope that's OK, I use jshint a lot and it's nice to keep quiet so that when it complains you know it's important
- when pasting, treat all individual values with the same steps - blank handling, duplicate handling, etc - that we were ding on individual inputs earlier
- when pasting, make the tags immediately - before we had to add a single trailing , to build the tags.

Hope that's OK. I've bumped the ver in both files to 0.8.1.
