### PR TITLE
preserve input type

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<link rel="stylesheet" type="text/css" href="tags-input.css">
+	<script type="text/javascript" src="tags-input.js"></script>
+	<style type="text/css">
+		body {
+			padding: 1em 3em;
+		}
+		form {
+			max-width: 40em;
+			margin: auto;
+		}
+		.tags-input {
+			width: 100%;
+			margin: 1em 0;
+		}
+	</style>
+</head>
+<body>
+	<form>
+		<label for='simple'>Simple</label>
+		<input id='simple' type='text'>
+		<label for='email'>Email</label>
+		<input id='email' type='email' data-separator=' '>
+		<label for='url'>URL</label>
+		<input id='url' type='url' data-separator=' '>
+	</form>
+	<script type="text/javascript">
+		for (let input of document.querySelectorAll('form input')) {
+			tagsInput(input);
+		}
+	</script>
+</body>

--- a/src/tags-input.js
+++ b/src/tags-input.js
@@ -106,13 +106,18 @@ export default function tagsInput(input) {
 
 	let base = createElement('div', 'tags-input'),
 		sib = input.nextSibling;
+
 	input.parentNode[sib?'insertBefore':'appendChild'](base, sib);
 
 	input.style.cssText = 'position:absolute;left:0;top:-99px;width:1px;height:1px;opacity:0.01;';
 	input.tabIndex = -1;
 
+	let inputType = input.getAttribute('type');
+	if (!inputType || inputType === 'tags') {
+		inputType = 'text';
+	}
 	base.input = createElement('input');
-	base.input.setAttribute('type', 'text');
+	base.input.setAttribute('type', inputType);
 	COPY_PROPS.forEach( prop => {
 		if (input[prop]!==base.input[prop]) {
 			base.input[prop] = input[prop];

--- a/src/tags-input.js
+++ b/src/tags-input.js
@@ -104,6 +104,16 @@ export default function tagsInput(input) {
 		return false;
 	}
 
+	function caretAtStart(el) {
+		try {
+			return el.selectionStart === 0 && el.selectionEnd === 0;
+		}
+		catch(e) {
+			return el.value === '';
+		}
+	}
+
+
 	let base = createElement('div', 'tags-input'),
 		sib = input.nextSibling;
 
@@ -145,7 +155,7 @@ export default function tagsInput(input) {
 		let el = base.input,
 			key = e.keyCode || e.which,
 			selectedTag = $('.tag.selected'),
-			pos = el.selectionStart===el.selectionEnd && el.selectionStart,
+			atStart = caretAtStart(el),
 			last = $('.tag',true).pop();
 
 		setInputWidth();
@@ -167,7 +177,7 @@ export default function tagsInput(input) {
 				setInputWidth();
 				save();
 			}
-			else if (last && pos===0) {
+			else if (last && atStart) {
 				select(last);
 			}
 			else {
@@ -180,7 +190,7 @@ export default function tagsInput(input) {
 					select(selectedTag.previousSibling);
 				}
 			}
-			else if (pos!==0) {
+			else if (!atStart) {
 				return;
 			}
 			else {


### PR DESCRIPTION
Don't change the input type if it is configured on the wrapped element: that allows using this component with input types like 'email', 'url', 'tel' etc. - important on handheld devices where keyboard type changes depending on the input type.
There is a problem with `selectionStart|End` for some type of inputs though. We can't reliably support some of the functionality that depends on detecting caret position. The workaround in 	0d9ae40 should work for most cases.